### PR TITLE
Added a 'show post's author' option to widget.

### DIFF
--- a/ultimate-posts-widget.php
+++ b/ultimate-posts-widget.php
@@ -191,6 +191,12 @@ if ( !class_exists( 'WP_Widget_Ultimate_Posts' ) ) {
 								</p>
 							<?php endif; ?>
 
+							<?php if( $instance['show_author'] ) : ?>
+								<p class="post-author">
+									<?php the_author_posts_link(); ?>
+								</p>
+							<?php endif; ?>
+
 							<?php if ( $instance['show_excerpt'] ) :
 								if ( $instance['show_readmore'] ) : $linkmore = ' <a href="'.get_permalink().'" class="more-link">'.$excerpt_readmore.'</a>'; else: $linkmore =''; endif; ?>
 								<p class="post-excerpt"><?php echo get_the_excerpt() . $linkmore; ?></p>
@@ -258,6 +264,7 @@ if ( !class_exists( 'WP_Widget_Ultimate_Posts' ) ) {
 			$instance['show_date'] = $new_instance['show_date'];
 			$instance['show_time'] = $new_instance['show_time'];
 			$instance['show_title'] = $new_instance['show_title'];
+			$instance['show_author'] = $new_instance['show_author'];
 			$instance['thumb_w'] = strip_tags( $new_instance['thumb_w'] );
 			$instance['thumb_h'] = strip_tags( $new_instance['thumb_h'] );
 			$instance['thumb_crop'] = $new_instance['thumb_crop'];
@@ -331,6 +338,7 @@ if ( !class_exists( 'WP_Widget_Ultimate_Posts' ) ) {
 				$instance['show_title'] = false;
 				$instance['show_date'] = false;
 				$instance['show_time'] = false;
+				$instance['show_author'] = false;
 				$instance['show_excerpt'] = false;
 				$instance['show_readmore'] = false;
 				$instance['show_thumbnail'] = false;
@@ -384,6 +392,11 @@ if ( !class_exists( 'WP_Widget_Ultimate_Posts' ) ) {
 			<p>
 				<input class="checkbox" id="<?php echo $this->get_field_id( 'show_time' ); ?>" name="<?php echo $this->get_field_name( 'show_time' ); ?>" type="checkbox" <?php checked( (bool) $instance["show_time"], true ); ?> />
 				<label for="<?php echo $this->get_field_id( 'show_time' ); ?>"><?php _e( 'Show published time', 'upw' ); ?></label>
+			</p>
+
+			<p>
+				<input class="checkbox" id="<?php echo $this->get_field_id( 'show_author' ); ?>" name="<?php echo $this->get_field_name( 'show_author' ); ?>" type="checkbox" <?php checked( (bool) $instance["show_author"], true ); ?> />
+				<label for="<?php echo $this->get_field_id( 'show_author' ); ?>"><?php _e( 'Show post author', 'upw' ); ?></label>
 			</p>
 
 			<p>


### PR DESCRIPTION
### What?

It displays the post's/page's author that links to their profile page.
### Why?

I really enjoyed the multitude of options the 'Ultimate Posts' widget gave me. However, if a blog has more than one author, I want to give the admin the ability to display a post's/page's author with a link to their profile page.
### How?

I simply added a 'show_author' option to the widget's $instance array. I also added in a simple checkbox to the widget's form template.  
