### PR TITLE
Search custom template both in child theme and in parent

### DIFF
--- a/ultimate-posts-widget.php
+++ b/ultimate-posts-widget.php
@@ -182,8 +182,8 @@ if ( !class_exists( 'WP_Widget_Ultimate_Posts' ) ) {
 
       if ($instance['template'] === 'custom') {
         $custom_template_path = apply_filters('upw_custom_template_path',  '/upw/' . $instance['template_custom'] . '.php', $instance, $this->id_base);
-        if (locate_template($custom_template_path)) {
-          include get_stylesheet_directory() . $custom_template_path;
+        if ( $template = locate_template($custom_template_path) ) {
+          include $template;
         } else {
           include 'templates/standard.php';
         }


### PR DESCRIPTION
Now the plugin loads custom templates only from current theme. That means only from child theme, and not also from parent theme as we expect (the plugin uses `locate_template` function to check if template exists and this function searches both in child and parent theme).

With this modification, the plugin searchs a custom template first in current/child theme, then in parent theme (if you are using a child theme).