### PR TITLE
ob_end_flush(); is needed or else the whole page gets messed up.

### DIFF
--- a/ultimate-posts-widget.php
+++ b/ultimate-posts-widget.php
@@ -214,6 +214,8 @@ if ( !class_exists( 'WP_Widget_Ultimate_Posts' ) ) {
         $cache[$args['widget_id']] = ob_get_flush();
       }
       wp_cache_set( 'widget_ultimate_posts', $cache, 'widget' );
+      ob_end_flush();
+
     }
 
     function update( $new_instance, $old_instance ) {


### PR DESCRIPTION
I don't know why, but the page is totally messed up (the second half of the source code goes on top and the first half on the bottom, which makes a big mess.

Adding  ob_end_flush(); here prevents that.